### PR TITLE
Delete Main platform CSS definition duplication

### DIFF
--- a/war/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/war/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -9,23 +9,6 @@
         <css-priority>10</css-priority>
     </portal-skin>
 
-
-    <portal-skin>
-        <skin-name>Enterprise</skin-name>
-        <skin-module>customModuleVuetify</skin-module>
-        <css-path>/../EnterpriseSkin/skin/css/vuetify/vuetify-all.css</css-path>
-        <css-priority>10</css-priority>
-    </portal-skin>
-
-
-    <portal-skin>
-        <skin-name>Enterprise</skin-name>
-        <skin-module>customModuleTaks</skin-module>
-        <css-path>/../task-management/skin/css/tasks.css</css-path>
-        <css-priority>10</css-priority>
-    </portal-skin>
-
-
     <portal-skin>
         <skin-name>Enterprise</skin-name>
         <skin-module>customModuleLeadCapture</skin-module>


### PR DESCRIPTION
Prior to this change, the builtin portal skins of eXo Platform are redefined and re-imported in page with a different module name.
This fix ensures to define only addon's CSS modules.
You can see on eXo Tribe the following problems in console:
![Capture d’écran du 2021-07-28 07-31-43](https://user-images.githubusercontent.com/594824/127275001-2c8ed15d-25dc-498c-97c8-05146be12132.png)
