### PR TITLE
fix : Lead Management application do not load - EXO-74214

### DIFF
--- a/war/src/main/webapp/vue-app/leadsManagement.js
+++ b/war/src/main/webapp/vue-app/leadsManagement.js
@@ -10,7 +10,7 @@ const vuetify = new Vuetify({
   iconfont: 'mdi',
 });
 
-$(document).ready(() => {
+function initLeadsManagement() {
   const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language;
   const urls = [`${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.LeadCapture-${lang}.json`,
   `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.taskManagement-${lang}.json`];
@@ -27,4 +27,10 @@ $(document).ready(() => {
           return translation !== key && translation || defaultValue;
       }
   });
-});
+}
+
+document.onreadystatechange = () => {
+  if (document.readyState === "complete") {
+    initLeadsManagement();
+  }
+};


### PR DESCRIPTION
Before this fix, leads management application do not load because the js which load the vue app is executed before the div#leadsManagementApp is loaded. The div was not founded. This commit change the document.ready by onreadyStateChange event to ensure the page is loaded before loding the vue app