### PR TITLE
fix: Capture emails not sent - EXO-75417 - fix: No activity related to manually created leads - EXO-75266

### DIFF
--- a/services/src/main/java/org/exoplatform/leadcapture/Utils.java
+++ b/services/src/main/java/org/exoplatform/leadcapture/Utils.java
@@ -304,12 +304,12 @@ public class Utils {
     ExoSocialActivity activity =  null;
     if (StringUtils.isNotEmpty(lead.getActivityId())) {
       activity = activityManager.getActivity(lead.getActivityId());
-    }
-    if (activity == null) {
-      activity = createActivity(lead);
-      if (activity != null) {
-        lead.setActivityId(activity.getId());
-        leadsManagementService.updateLead(leadsManagementService.toLeadDto(lead));
+      if (activity == null) {
+        activity = createActivity(lead);
+        if (activity != null) {
+          lead.setActivityId(activity.getId());
+          leadsManagementService.updateLead(leadsManagementService.toLeadDto(lead));
+        }
       }
     }
     Identity posterIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, botName);

--- a/services/src/main/java/org/exoplatform/leadcapture/listeners/NewResponseListener.java
+++ b/services/src/main/java/org/exoplatform/leadcapture/listeners/NewResponseListener.java
@@ -1,5 +1,8 @@
 package org.exoplatform.leadcapture.listeners;
 
+import static org.exoplatform.leadcapture.Utils.isResourceRequest;
+import static org.exoplatform.leadcapture.Utils.saveComment;
+
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -17,8 +20,6 @@ import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-
-import static org.exoplatform.leadcapture.Utils.*;
 
 public class NewResponseListener extends Listener<LeadEntity, ResponseEntity> {
 
@@ -54,7 +55,11 @@ public class NewResponseListener extends Listener<LeadEntity, ResponseEntity> {
     String resourceName = null;
     ResourceEntity resource = null;
     ResponseEntity responseEntity = event.getData();
-    if(StringUtils.isNotEmpty(lead.getActivityId()))saveComment(lead.getActivityId(), responseEntity);
+    try {
+      saveComment(lead, responseEntity);
+    } catch (Exception e) {
+      LOG.warn("Cannot add comment to the lead {} activity", lead.getMail());
+    }
     List<MailTemplateEntity> templates = mailTemplatesManagementService.getTemplatesbyEvent("newResponse");
     for (MailTemplateEntity template : templates) {
       if (StringUtils.isNotEmpty(template.getForm()) && !responseEntity.getFormEntity().getName().equals(template.getForm())) {

--- a/services/src/main/java/org/exoplatform/leadcapture/rest/LeadsManagementRest.java
+++ b/services/src/main/java/org/exoplatform/leadcapture/rest/LeadsManagementRest.java
@@ -13,11 +13,11 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.services.rest.http.PATCH;
-import org.exoplatform.task.exception.EntityNotFoundException;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
 import org.exoplatform.leadcapture.Utils;
 import org.exoplatform.leadcapture.dto.FormInfo;
 import org.exoplatform.leadcapture.dto.LeadCaptureSettings;
@@ -30,9 +30,11 @@ import org.exoplatform.leadcapture.services.LeadsManagementService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.services.rest.http.PATCH;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.service.rest.Util;
+import org.exoplatform.task.exception.EntityNotFoundException;
 
 @Path("/leadcapture/leadsmanagement")
 @Produces(MediaType.APPLICATION_JSON)
@@ -635,7 +637,7 @@ public class LeadsManagementRest implements ResourceContainer {
       lead.setUpdatedDate(new Date());
       lead.setStatus(LEAD_DEFAULT_STATUS);
       lead.setCaptureMethod("manually_created");
-      leadsManagementService.createLead(lead);
+      leadsManagementService.createLead(lead,sourceIdentity.getRemoteId());
       LOG.info("service=lead-capture operation=synchronize_lead parameters=\"lead_name:{}\"",
                lead.getFirstName() + " " + lead.getLastName());
 

--- a/services/src/main/java/org/exoplatform/leadcapture/services/LeadsManagementService.java
+++ b/services/src/main/java/org/exoplatform/leadcapture/services/LeadsManagementService.java
@@ -9,15 +9,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.api.persistence.ExoTransactional;
-import org.exoplatform.task.domain.Priority;
-import org.exoplatform.task.dto.*;
-import org.exoplatform.task.service.*;
-import org.exoplatform.task.util.ResourceUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.leadcapture.Utils;
 import org.exoplatform.leadcapture.dao.FieldDAO;
@@ -38,7 +34,11 @@ import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvide
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.task.domain.Priority;
+import org.exoplatform.task.dto.*;
 import org.exoplatform.task.exception.EntityNotFoundException;
+import org.exoplatform.task.service.*;
+import org.exoplatform.task.util.ResourceUtil;
 import org.exoplatform.task.util.TaskUtil;
 
 public class LeadsManagementService {
@@ -164,6 +164,22 @@ public class LeadsManagementService {
 
   public LeadEntity createLead(LeadDTO lead) {
     return leadDAO.create(toLeadEntity(lead));
+  }
+
+  public LeadEntity createLead(LeadDTO lead, String creator) throws Exception {
+    LeadEntity leadEntity = toLeadEntity(lead);
+    leadEntity = leadDAO.create(leadEntity);
+    ResponseDTO responseDTO = new ResponseDTO();
+    responseDTO.setFormName("Created manually");
+    List<FieldDTO> fields = new ArrayList<>();
+    FieldDTO fieldDTO = new FieldDTO();
+    fieldDTO.setName("Created by");
+    fieldDTO.setValue(creator);
+    fields.add(fieldDTO);
+    responseDTO.setFields(fields);
+    addResponse(responseDTO, leadEntity);
+    listenerService.broadcast(NEW_LEAD_EVENT, leadEntity, "");
+    return leadEntity;
   }
 
   @ExoTransactional


### PR DESCRIPTION
- Prior to this, mails are not sent if the lead activity was not found
This commit created a new activity and add the comment when the old activity is not found

- Prior to this, manually created leads have no activity in the space stream and empty timeline
This commit creates an activity when the lead is created manually and adds this info to the timeline