### PR TITLE
fix: Improve Leads REST error handling and prevent internal exception leakage - EXO-87040

### DIFF
--- a/services/src/main/java/org/exoplatform/leadcapture/rest/LeadsManagementRest.java
+++ b/services/src/main/java/org/exoplatform/leadcapture/rest/LeadsManagementRest.java
@@ -15,14 +15,11 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.leadcapture.dto.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.exoplatform.leadcapture.Utils;
-import org.exoplatform.leadcapture.dto.FormInfo;
-import org.exoplatform.leadcapture.dto.LeadCaptureSettings;
-import org.exoplatform.leadcapture.dto.LeadDTO;
-import org.exoplatform.leadcapture.dto.PersonalTask;
 import org.exoplatform.leadcapture.entity.LeadEntity;
 import org.exoplatform.leadcapture.entity.ResponseEntity;
 import org.exoplatform.leadcapture.services.LeadCaptureSettingsService;
@@ -92,10 +89,11 @@ public class LeadsManagementRest implements ResourceContainer {
     }
     try {
 
-      return Response.ok(leadsManagementService.getLeads(search, status, owner, captureMethod, from, to, zone, min, max, notassigned, sortBy, sortDesc, page, limit, export)).build();
+      LeadsAccessList leads = leadsManagementService.getLeads(search, status, owner, captureMethod, from, to, zone, min, max, notassigned, sortBy, sortDesc, page, limit, export);
+      return Response.ok(leads).build();
     } catch (Exception e) {
       LOG.error("An error occured when trying to get leads list", e);
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Internal server error").build();
     }
   }
 


### PR DESCRIPTION
Before this change, the Leads REST endpoint directly exposed the result of getLeads() and internal exception messages, which could lead to leaking sensitive error details to the client. To fix this problem, the service call was wrapped inside a proper try/catch block and REST responses were standardized to return a generic HTTP 500 error without exposing internal exception messages. After this change, the API safely handles runtime exceptions, logs full error details on the server side, and returns clean error responses to clients without leaking internal system information.